### PR TITLE
Changes .load() return when creating new Map object

### DIFF
--- a/lib/Google.js
+++ b/lib/Google.js
@@ -74,7 +74,7 @@
 				GoogleMapsLoader.createLoader();
 			}
 		} else if (fn) {
-			fn(google);
+			return fn(google);
 		}
 
 		var promiseError = function() {


### PR DESCRIPTION
Based on the suggested implementation, it could be useful to be able to return the new Map instances from the callback. Being able to do something like this:

```javascript
let map = GoogleMapsLoader.load(google => new google.maps.Map( ... ));
```