### PR TITLE
sensor url param throw a warning

### DIFF
--- a/lib/Google.js
+++ b/lib/Google.js
@@ -107,9 +107,11 @@
 		var url = GoogleMapsLoader.URL;
 
 		url += '?callback=' + GoogleMapsLoader.WINDOW_CALLBACK_NAME;
-
-		url += '&sensor=' + ((GoogleMapsLoader.SENSOR === true || GoogleMapsLoader.SENSOR === 'true') ? 'true' : 'false');
-
+		
+		if(GoogleMapsLoader.SENSOR) {
+			url += '&sensor=true' + ((GoogleMapsLoader.SENSOR === true || GoogleMapsLoader.SENSOR === 'true') ? 'true' : 'false');
+		}
+		
 		if (GoogleMapsLoader.KEY) {
 			url += '&key=' + GoogleMapsLoader.KEY;
 		}


### PR DESCRIPTION
Hi, 
Today the "sensor" url param is not required and throw a warning.
So it is not mandatory for false value...